### PR TITLE
Fix cross references

### DIFF
--- a/book/ch00.adoc
+++ b/book/ch00.adoc
@@ -17,8 +17,8 @@ available and maintained, as a tool instead of as a commodity.
 The next question is not always about money, though. The business case
 for open source softwarefootnote:[The terms "open source software" and
 "free software" are essentially synonymous in this context; they are
-discussed more in link:#free-vs-open-source[???]in
-link:#introduction[???].] is no longer so mysterious, and even
+discussed more in <<free-vs-open-source>> in
+<<introduction>>.] is no longer so mysterious, and even
 non-programmers already understand—or at least are not surprised—that
 there are people employed at it full time. Instead, the next question is
 often "__Oh, how does that work?__"

--- a/book/ch01.adoc
+++ b/book/ch01.adoc
@@ -28,7 +28,7 @@ Did the first project end, or just change homes?
 Because of such complexities, it's impossible to put a precise number on
 the failure rate. But anecdotal evidence from two decades in open
 source, some casting around on multi-project hosting sites (see
-link:#canned-hosting[???]in link:#technical-infrastructure[???] for more
+<<canned-hosting>> in <<technical-infrastructure>> for more
 about them), and a little Googling all point to the same conclusion: the
 rate is extremely high, probably on the order of 90–95%. The number
 climbs higher if you include surviving but dysfunctional projects: those
@@ -106,7 +106,7 @@ software, because they wrote it. Second, the skills required to do
 presentation and packaging well are often completely different from
 those required to write code. People tend to focus on what they're good
 at, even if it might serve the project better to spend a little time on
-something that suits them less. link:#getting-started[???] discusses
+something that suits them less. <<getting-started>> discusses
 presentation and packaging in detail, and explains why it's crucial that
 they be a priority from the very start of the project.
 
@@ -162,7 +162,7 @@ realizing that, on the whole, my experiences indicated that governments
 are less naturally suited to participating in free software projects
 than private-sector, for-profit corporations, with non-profits somewhere
 in between the two. There are many reasons for this (see
-link:#governments-and-open-source[???]), and the problems are certainly
+<<governments-and-open-source>>), and the problems are certainly
 surmountable, but it's worth noting that when an existing
 organization — particularly a hierarchical one, and _particularly_ a
 hierarchical, risk-averse, and publicity-sensitive one — starts or joins
@@ -346,7 +346,7 @@ simply putting his code into the public domain. If it were in the public
 domain, any particular copy of it could be incorporated into a
 proprietary program (as also sometimes happens to code under permissive
 open source copyright licenses footnote:[See
-link:#licenses-terminology[???] for more about "permissive" licensing
+<<licenses-terminology>> for more about "permissive" licensing
 versus GPL-style "copyleft" licensing. The opensource.org FAQ is also a
 good resource on
 this—seehttp://opensource.org/faq#copyleft[opensource.org/faq#copyleft].]).
@@ -356,7 +356,7 @@ efforts could benefit the enemy—proprietary software. The GPL can be
 thought of as a form of protectionism for free software, because it
 prevents non-free software from taking full advantage of GPLed code. The
 GPL and its relationship to other free software licenses are discussed
-in detail in link:#legal[???].
+in detail in <<legal>>.
 
 With the help of many programmers, some of whom shared Stallman's
 ideology and some of whom simply wanted to see a lot of free code
@@ -440,7 +440,7 @@ publishing-quality typesetting system. He released it under terms that
 allowed anyone to modify and distribute the code, but not to call the
 result "TeX" unless it passed a very strict set of compatibility tests
 (this is an example of the "trademark-protecting" class of free
-licenses, discussed more in link:#legal[???]). Knuth wasn't taking a
+licenses, discussed more in <<legal>>). Knuth wasn't taking a
 stand one way or the other on the question of free-versus-proprietary
 software; he just needed a better typesetting system in order to
 complete his _real_ goal—a book on computer programming—and saw no
@@ -705,11 +705,11 @@ potential contributors and, if you must discriminate, do so only on the
 basis of actual behavior, not on the basis of a contributor's group
 affiliation or group identity.]. Clearly, projects with corporate
 sponsorship and/or salaried developers need to be especially careful in
-this regard, as link:#money[???] discusses in detail. Of course, this
+this regard, as <<money>> discusses in detail. Of course, this
 doesn't mean that if there's no corporate sponsorship then you have
 nothing to worry about. Money is merely one of many factors that can
 affect the success of a project. There are also questions of what
 language to choose, what license, what development process, precisely
 what kind of infrastructure to set up, how to publicize the project's
 inception effectively, and much more. Starting a project out on the
-right foot is the topic of link:#getting-started[the next chapter].
+right foot is the topic of <<getting-started>>.

--- a/book/ch02.adoc
+++ b/book/ch02.adoc
@@ -111,7 +111,7 @@ not be wasted if you get involved," which is exactly what people need to
 hear.
 
 If you use a "canned hosting" site (see
-link:#starting-with-canned-hosting[anchor_title]), one advantage of that
+<<canned-hosting>>), one advantage of that
 choice is that those sites have a default layout that is similar from
 project to project, and is pretty well-suited to presenting a project to
 the world. That layout can be customized, within certain boundaries, but
@@ -243,7 +243,7 @@ track of everything that's available on the Net already, without
 different things having the same name.
 +
 The resources mentioned earlier in
-link:#look-around[But First, Look Around] are useful in discovering
+<<look-around>> are useful in discovering
 whether another project already has the name you're thinking of. For the
 U.S., trademark searches are available at
 http://www.uspto.gov/[uspto.gov].
@@ -253,12 +253,12 @@ the official home site for the project; the other two should forward
 there and are simply to prevent third parties from creating identity
 confusion around the project's name. Even if you intend to host the
 project at some other site (see
-link:#starting-with-canned-hosting[anchor_title]), you can still
+<<canned-hosting>>), you can still
 register project-specific domains and forward them to the hosting site.
 It helps users a lot to have a simple URL to remember.
 * If possible, is available as a username on
 https://twitter.com/[Twitter] and other microblog sites. See
-link:#own-the-name[Own the name in the important namespaces] for more on
+<<own-the-name>> for more on
 this and its relationship to the domain name.
 
 [[own-the-name]]
@@ -295,7 +295,7 @@ https://github.com/gnome[gnome] username at GitHub.comfootnote:[While
 the master copy of Gnome's source code is at
 http://git.gnome.org/[git.gnome.org], they maintain a mirror at GitHub,
 since so many developers are already familiar with GitHub], and on the
-freenode IRC network (see link:#irc[???]) they have the channel
+freenode IRC network (see <<irc>>) they have the channel
 `#gnome`, although they also maintain their own IRC servers (where they
 control the channel namespace anyway, of course).
 
@@ -376,9 +376,9 @@ Please don't make this mistake. Such an omission can lose many potential
 developers and users. State up front, right below the mission statement,
 that the project is "free software" or "open source software", and give
 the exact license. A quick guide to choosing a license is given in
-link:#license-quickstart[Choosing a License and Applying It]later in
+<<license-quickstart>> later in
 this chapter, and licensing issues are discussed in detail in
-link:#legal[???].
+<<legal>>.
 
 By this point, our hypothetical visitor has determined—probably in a
 minute or less—that she's interested in spending, say, at least five
@@ -561,9 +561,9 @@ number, so that people can compare any two releases and know which
 supersedes the other. That way they can report bugs against a particular
 release (which helps respondents to figure out if the bug is already
 fixed or not). A detailed discussion of version numbering can be found
-in link:#release-numbering[???], and the details of standardizing build
-and installation procedures are covered in link:#packaging[???], both in
-link:#development-cycle[???].
+in <<release-numbering>>, and the details of standardizing build
+and installation procedures are covered in <<packaging>>, both in
+<<development-cycle>>.
 
 [[vc-and-bug-tracker-access]]
 ==== Version Control and Bug Tracker Access
@@ -588,9 +588,9 @@ for most projectsfootnote:[Although GitHub is based on Git, a popular
 open source version control system, the code that runs GitHub's web
 services is not itself open source. Whether this matters for your
 project is a complex question, and is addressed in more depth in
-link:#canned-hosting[???]in link:#technical-infrastructure[???]].
-Version control infrastructure is discussed in detail in link:#vc[???]in
-link:#technical-infrastructure[???].
+<<canned-hosting>> in <<technical-infrastructure>>].
+Version control infrastructure is discussed in detail in <<vc>> in
+<<technical-infrastructure>>.
 
 The same goes for the project's bug tracker. The importance of a bug
 tracking system lies not only in its day-to-day usefulness to
@@ -627,7 +627,7 @@ user engagement.]
 Note that bug trackers are often used to track not only software bugs,
 but enhancement requests, documentation changes, pending tasks, and
 more. The details of running a bug tracker are covered in
-link:#bug-tracker[???]in link:#technical-infrastructure[???], so I won't
+<<bug-tracker>> in <<technical-infrastructure>>, so I won't
 go into them here. The important thing from a presentation point of view
 is just to _have_ a bug tracker, and to make sure that fact is visible
 from the front page of the project.
@@ -637,7 +637,7 @@ from the front page of the project.
 
 Visitors usually want to know how to reach the human beings involved
 with the project. Provide the addresses of mailing lists, chat rooms,
-IRC channels (link:#technical-infrastructure[???]), and any other forums
+IRC channels (<<technical-infrastructure>>), and any other forums
 where others involved with the software can be reached. Make it clear
 that you and the other authors of the project are subscribed to these
 mailing lists, so people see there's a way to give feedback that will
@@ -660,7 +660,7 @@ of the project's direction.
 
 As this chapter is only about getting a project started, it's enough
 merely to say that these communications forums need to exist. Later, in
-link:#growth[???]in link:#communications[???], we'll examine where and
+<<growth>> in <<communications>>, we'll examine where and
 how to set up such forums, the ways in which they might need moderation
 or other management, and how to separate user forums from developer
 forums, when the time comes, without creating an unbridgeable gulf.
@@ -673,8 +673,8 @@ developer guidelines. Developer guidelines are not so much technical as
 social: they explain how the developers interact with each other and
 with the users, and ultimately how things get done.
 
-This topic is covered in detail in link:#written-rules[???]in
-link:#social-infrastructure[???], but the basic elements of developer
+This topic is covered in detail in <<written-rules>> in
+<<social-infrastructure>>, but the basic elements of developer
 guidelines are:
 
 * pointers to forums for interaction with other developers
@@ -689,7 +689,7 @@ power over all changes. Many successful projects work this way. The
 important thing is that the project come right out and say so. A tyranny
 pretending to be a democracy will turn people off; a tyranny that says
 it's a tyranny will do fine as long as the tyrant is competent and
-trusted. (See link:#forkability[???]in link:#social-infrastructure[???]
+trusted. (See <<forkability>> in <<social-infrastructure>>
 for why dictatorship in open source projects doesn't have the same
 implications as dictatorship in other areas of life.)
 
@@ -701,7 +701,7 @@ are also a good example.
 
 The separate issue of providing a programmer's introduction to the
 software is discussed in
-link:#developer-documentation[Developer documentation]later in this
+<<developer-documentation>> later in this
 chapter.
 
 [[documentation]]
@@ -805,17 +805,17 @@ and answers, so there will be an obvious place for people to contribute
 questions and answers after the project is under way. At this stage, the
 most important property is not completeness, but __convenience__: if the
 FAQ is easy to add to, people will add to it. (Proper FAQ maintenance is
-a non-trivial and intriguing problem: see link:#faq-manager[???]in
-link:#managing-volunteers[???], link:#q-and-a-forums[???]in
-link:#technical-infrastructure[???], and link:#all-as-archives[???]in
-link:#communications[???].)
+a non-trivial and intriguing problem: see <<faq-manager>> in
+<<managing-volunteers>>, <<q-and-a-forums>> in
+<<technical-infrastructure>>, and <<all-as-archives>> in
+<<communications>>.)
 
 [[documentation-availability]]
 ===== Availability of documentation
 
 Documentation should be available from two places: online (directly from
 the web site), _and_ in the downloadable distribution of the software
-(see link:#packaging[???]in link:#development-cycle[???]). It needs to
+(see <<packaging>> in <<development-cycle>>). It needs to
 be online, in browsable form, because people often read documentation
 _before_ downloading software for the first time, as a way of helping
 them decide whether to download at all. But it should also accompany the
@@ -877,7 +877,7 @@ Some projects use wikis for their initial documentation, or even as
 their primary documentation. In my experience, this works best if the
 wiki is actively maintained by a few people who agree on how the
 documentation is to be organized and what sort of "voice" it should
-have. See link:#wikis[???]in link:#technical-infrastructure[???] for
+have. See <<wikis>> in <<technical-infrastructure>> for
 more.
 
 [[examples-and-demos]]
@@ -969,8 +969,8 @@ open source projects. By far the most popular such site, as of this
 writing in mid-2013, is https://github.com/[GitHub.com], and if you
 don't have a strong preference about where to host, you should probably
 just choose GitHub; many developers are already familiar with it and
-have personal accounts there. link:#canned-hosting[???]in
-link:#technical-infrastructure[???] has a more detailed discussion of
+have personal accounts there. <<canned-hosting>> in
+<<technical-infrastructure>> has a more detailed discussion of
 the questions to consider when choosing a canned hosting site, and an
 overview of the most popular ones.
 
@@ -978,7 +978,7 @@ overview of the most popular ones.
 === Choosing a License and Applying It
 
 This section is intended to be a very quick, very rough guide to
-choosing a license. Read link:#legal[???] to understand the detailed
+choosing a license. Read <<legal>> to understand the detailed
 legal implications of the different licenses, and how the license you
 choose can affect people's ability to mix your software with other
 software.
@@ -996,7 +996,7 @@ Initiative as meeting the Open Source Definition
 the FSF's definition of free software, and the OSI's definition of open
 source software, it becomes obvious that the two definitions delineate
 the same freedoms — not surprisingly, as
-link:#free-vs-open-source[???]in link:#introduction[???] explains. The
+<<free-vs-open-source>> in <<introduction>> explains. The
 inevitable, and in some sense deliberate, result is that the two
 organizations have approved the same set of licenses.footnote:[There are
 actually some minor differences between the sets of approved licenses,
@@ -1034,7 +1034,7 @@ proprietary programs, then use an MIT/X-style license. It is the
 simplest of several minimal licenses that do little more than assert
 nominal copyright (without actually restricting copying) and specify
 that the code comes with no warranty. See
-link:#license-choosing-mit-x[???] for details.
+<<license-choosing-mit-x>> for details.
 
 [[license-quickstart-gpl]]
 ==== The GPL
@@ -1046,14 +1046,14 @@ GPL is probably the most widely recognized free software license in the
 world today. This is in itself a big advantage, since many potential
 users and contributors will already be familiar with it, and therefore
 won't have to spend extra time to read and understand your license. See
-link:#license-choosing-gpl[???]in link:#legal[???] for details.
+<<license-choosing-gpl>> in <<legal>> for details.
 
 If users interact with your code primarily over a network—that is, the
 software is usually part of a hosted service, rather than being
 distributed as a binary—then consider using the GNU Affero GPL instead.
 The AGPL is just the GPL with one extra clause establishing network
 accessibility as a form of distribution for the purposes of the license.
-See link:#gnu-affero-gpl[???]in link:#legal[???] for more.
+See <<gnu-affero-gpl>> in <<legal>> for more.
 
 [[license-quickstart-applying]]
 ==== How to Apply a License to Your Software
@@ -1211,8 +1211,8 @@ This is a skill that requires practice, and you can't get that practice
 by talking to people who already know what you know.
 * The discussion and its conclusions will be available in public
 archives forever after, enabling future discussions to avoid retracing
-the same steps. See link:#using-archives[???]in
-link:#communications[???].
+the same steps. See <<using-archives>> in
+<<communications>>.
 
 Finally, there is the possibility that someone on the list may make a
 real contribution to the conversation, by coming up with an idea you
@@ -1391,10 +1391,10 @@ effectively. In particular, setting up commit emails is extremely
 useful. The effect of commit emails is that every time someone commits a
 change to the central repository, an email goes out showing the log
 message and diffs (unless the diff is too large; see
-link:#vc-vocabulary-diff[???], in link:#vc-vocabulary[???]). The review
+<<vc-vocabulary-diff>>, in <<vc-vocabulary>>). The review
 itself might take place on a mailing list, or in a review tool such as
 Gerrit or the GitHub "pull request" interface. See
-link:#commit-emails[???]in link:#technical-infrastructure[???] for
+<<commit-emails>> in <<technical-infrastructure>> for
 details.
 
 [[subversion-commit-review]]
@@ -1548,8 +1548,8 @@ never would have if the issues had come up piecemeal in the normal
 course of development.
 
 (These concerns apply even more strongly to government software
-projects; see link:#starting-open-for-govs[???]in
-link:#governments-and-open-source[???].)
+projects; see <<starting-open-for-govs>> in
+<<governments-and-open-source>>.)
 
 The good news is that these are all unforced errors. A project incurs
 little extra cost by avoiding them in the simplest way possible: by
@@ -1586,7 +1586,7 @@ done in a way that's compatible with being open source.
 ==== When Opening a Formerly Closed Project, be Sensitive to the
 Magnitude of the Change
 
-As per link:#be-open-from-day-one[Be Open From Day One], it's best to
+As per <<be-open-from-day-one>>, it's best to
 avoid being in the situation of opening up a closed project in the first
 place; just start the project in the open if you can. But if it's too
 late for that, and you find yourself opening up an existing project that
@@ -1613,7 +1613,7 @@ team of perfect coders, this is unavoidable—in fact, it will probably
 happen to all of them at first. This is not because they're bad
 programmers; it's just that any program above a certain size has bugs,
 and peer review will spot some of those bugs (see
-link:#code-review[Practice Conspicuous Code Review]earlier in this
+<<code-review>> earlier in this
 chapter). At the same time, the newcomers themselves won't be subject to
 much peer review at first, since they can't contribute code until
 they're more familiar with the project. To your developers, it may feel
@@ -1643,8 +1643,8 @@ which this might happen, so you can ask that such discussions be moved
 to the public lists right away.
 
 There are other, longer-term concerns with opening up formerly closed
-projects. link:#money[???] explores techniques for mixing paid and
-unpaid developers successfully, and link:#legal[???] discusses the
+projects. <<money>> explores techniques for mixing paid and
+unpaid developers successfully, and <<legal>> discusses the
 necessity of legal diligence when opening up a private code base that
 may contain software written or "owned" by other parties.
 
@@ -1721,7 +1721,7 @@ Thank you,
 -J. Random
 ....
 
-(See link:#publicity[???]in link:#communications[???] for advice on
+(See <<publicity>> in <<communications>> for advice on
 announcing subsequent releases and other project events.)
 
 There is an ongoing debate in the free software world about whether it
@@ -1751,7 +1751,7 @@ the timing of your announcement should not be taken as advice to delay
 open sourcing the code — ideally, your project should be open source and
 publicly visible from the very first moment of its existence, and this
 is entirely independent of when you announce it. See
-link:#be-open-from-day-one[Be Open From Day One] for more.]. However,
+<<be-open-from-day-one>> for more.]. However,
 there may be circumstances where announcing earlier makes sense. I do
 think that at least a well-developed design document, or else some sort
 of code framework, is necessary—of course it may be revised based on

--- a/book/ch03.adoc
+++ b/book/ch03.adoc
@@ -74,13 +74,13 @@ technical skills are essential because information management software
 always requires configuration, plus a certain amount of ongoing
 maintenance and tweaking as new needs arise (for example, see the
 discussion of how to handle project growth in
-link:#bug-filtering[Pre-Filtering the Bug Tracker]later in this
+<<bug-filtering>> later in this
 chapter). The people skills are necessary because the human community
 also requires maintenance: it's not always immediately obvious how to
 use these tools to full advantage, and in some cases projects have
 conflicting conventions (for example, see the discussion of setting
 Reply-to headers on outgoing mailing list posts, in
-link:#message-forums[Mailing Lists / Message Forums]). Everyone involved
+<<message-forums>>). Everyone involved
 with the project will need to be encouraged, at the right times and in
 the right ways, to do their part to keep the project's information well
 organized. The more involved the contributor, the more complex and
@@ -98,7 +98,7 @@ doesn't use it—for example, this happened to a lot of free software
 projects that predate the invention of the wiki (see
 http://en.wikipedia.org/wiki/Wiki[en.wikipedia.org/wiki/Wiki]), and more
 recently has been happening to projects whose workflows were developed
-before the rise of GitHub PRs (see link:#pull-requests[Pull requests])
+before the rise of GitHub PRs (see <<pull-requests>>)
 as the canonical way to package proposed contributions. Many
 infrastructure questions are matters of judgement, involving tradeoffs
 between the convenience of those producing information and the
@@ -149,7 +149,7 @@ You may be able to avoid a lot of the headache of choosing and
 configuring many of these tools by using a canned hosting site: an
 online service that offers prepackaged, templatized web services with
 some or all of the collaboration tools needed to run a free software
-project. See link:#canned-hosting[Canned Hosting]later in this chapter
+project. See <<canned-hosting>> later in this chapter
 for a discussion of the advantages and disadvantages of canned hosting.
 
 [[web-site]]
@@ -264,7 +264,7 @@ A perfect example of this is the handling of generated files. Certain
 project web pages may be generated files—for example, there are systems
 for keeping FAQ data in an easy-to-edit master format, from which HTML,
 PDF, and other presentation formats can be generated. As explained in
-link:#version-everything[Version everything]earlier in this chapter, you
+<<version-everything>> earlier in this chapter, you
 wouldn't want to version the generated formats, only the master file.
 But when your web site is hosted on someone else's server, it may be
 difficult to set up a custom hook to regenerate the online HTML version
@@ -508,7 +508,7 @@ Moderation features::
   sure they are not spam before they go out to the entire list.
   Moderation necessarily involves human administrators, but software can
   do a great deal to make it easier on the moderators. There is more
-  said about moderation in link:#spam-prevention[Spam Prevention] later
+  said about moderation in <<spam-prevention>> later
   in this chapter.
 Rich administrative interface::
   There are many things administrators need to do besides spam
@@ -523,11 +523,11 @@ Header manipulation::
   Some people have sophisticated filtering and replying rules set up in
   their mail readers, and rely on the forum adding or manipulating
   certain standard headers. See
-  link:#header-management[Identification and Header Management] later in
+  <<header-management>> later in
   this chapter for more on this.
 Archiving::
   All posts to the managed lists are stored and made available on the
-  web (see link:#using-archives[???]in link:#communications[???] for
+  web (see <<using-archives>> in <<communications>> for
   more on the importance of public archives). Usually the archiver is a
   native part of the message forum system; occasionally, it is a
   separate tool that needs to be integrated.
@@ -590,7 +590,7 @@ any amount of automated filtering is beneficial.
 There is not space here for detailed instructions on setting up spam
 filters. You will have to consult your mailing list software's
 documentation for that (see
-link:#mailing-list-software[anchor_title]later in this chapter). List
+<<mailing-list-software>> later in this chapter). List
 software often comes with some built-in spam prevention features, but
 you may want to add some third-party filters. I've had good experiences
 with SpamAssassin
@@ -822,7 +822,7 @@ unsubscribe.
 [[reply-to]]
 ===== The Great Reply-to Debate
 
-Earlier, in link:#avoid-private-discussions[???], I stressed the
+Earlier, in <<avoid-private-discussions>>, I stressed the
 importance of making sure discussions stay in public forums, and talked
 about how active measures are sometimes needed to prevent conversations
 from trailing off into private email threads; furthermore, this chapter
@@ -1011,7 +1011,7 @@ Referential stability::
   for Internet search engines to index the archives, which is a major
   boon to users looking for answers. Stable references are also
   important because mailing list posts and threads are often linked to
-  from the bug tracker (see link:#bug-tracker[Bug Tracker]later in this
+  from the bug tracker (see <<bug-tracker>> later in this
   chapter) or from other project documents.
   +
   Ideally, mailing list software would include a message's archive URL,
@@ -1041,7 +1041,7 @@ Searchability::
 The above is just a technical checklist to help you evaluate and set up
 an archiver. Getting people to actually _use_ the archiver to the
 project's advantage is discussed in later chapters, in particular
-link:#using-archives[???].
+<<using-archives>>.
 
 [[message-forum-software]]
 ===== Mailing List / Message Forum Software
@@ -1185,7 +1185,7 @@ pull::
   +
   To pull others' changes (commits) into your local copy of the project.
   When pulling changes from a project's mainline development branch (see
-  link:#vc-vocabulary-branch[varlistentry_title]), people often say
+  <<vc-vocabulary-branch>>), people often say
   "update" instead of "pull", for example: "Hey, I noticed the indexing
   code is always dropping the last byte. Is this a new bug?" "Yes, but
   it was fixed last week—try updating and it should go away."
@@ -1197,8 +1197,8 @@ commit message __or__ log message::
   the detailed, highly technical meaning of each individual code changes
   and the more user-visible world of bugfixes, features and project
   progress. Later in this section, we'll look at ways to distribute them
-  to the appropriate audiences; also, link:#codifying-tradition[???]in
-  link:#communications[???] discusses ways to encourage contributors to
+  to the appropriate audiences; also, <<codifying-tradition>> in
+  <<communications>> discusses ways to encourage contributors to
   write concise and useful commit messages.
 repository::
   A database in which changes are stored and from which they are
@@ -1211,14 +1211,14 @@ repository::
   from which public releases are rolled) is defined purely by social
   convention, instead of by a combination of social convention and
   technical enforcement.
-clone __(see also link:#vc-vocabulary-checkout[varlistentry_title])__::
+clone __(see also <<vc-vocabulary-checkout>>)__::
   To obtain one's own development repository by making a copy of the
   project's central repository.
 checkout::
   When used in discussion, "checkout" usually means something like
   "clone", except that centralized systems don't really clone the full
   repository, they just obtain a
-  link:#vc-vocabulary-working-copy[varlistentry_title]. When
+  <<vc-vocabulary-working-copy>>. When
   decentralized systems use the word "checkout", they also mean the
   process of obtaining working files from a repository, but since the
   repository is local in that case, the user experience is quite
@@ -1290,14 +1290,14 @@ branch::
   meanwhile, on the release branch, no changes are allowed except those
   approved by the release managers. This way, making a release needn't
   interfere with ongoing development work. See
-  link:#branches[Use branches to avoid bottlenecks]later in this chapter
+  <<branches>> later in this chapter
   for a more detailed discussion of branching.
 merge __or__ port::
   To move a change from one branch to another. This includes merging
   from the main trunk to some other branch, or vice versa. In fact,
   those are the most common kinds of merges; it is less common to port a
   change between two non-trunk branches. See
-  link:#vc-singularity[Singularity of information] for more on change
+  <<vc-singularity>> for more on change
   porting.
   +
   "Merge" has a second, related meaning: it is what some version control
@@ -1355,7 +1355,7 @@ offered at many different free hosting services; some services even
 support more than one of them (though GitHub only supports Git, as its
 name suggests). While some projects host their repositories on their own
 servers, most just put their repositories on one of the free hosting
-services, as described in link:#canned-hosting[Canned Hosting].
+services, as described in <<canned-hosting>>.
 
 There isn't space here for an in-depth exploration of why you might
 choose something other than Git. If you have a reason to do so, then you
@@ -1413,7 +1413,7 @@ project's bug tracker and its wiki hold plenty of editable data, but
 usually do not store that data in the main version control
 systemfootnote:[There are development environments that integrate
 everything into one unified version control world; see
-link:#vc-veracity[???] for an example.]. However, they should still have
+<<vc-veracity>> for an example.]. However, they should still have
 versioning systems of their own, e.g., the comment history in a bug
 ticket, and the ability to browse past revisions and view differences
 between them in a wiki.
@@ -1475,7 +1475,7 @@ make a copy of the castle, take it off to an isolated corner, and try
 out the new drawbridge design. If the effort succeeds, she can invite
 the other developers to examine the result (in GitHub-speak, this
 invitation is known as a "pull request" — see
-link:#pull-requests[Pull requests]). If everyone agrees that the result
+<<pull-requests>>). If everyone agrees that the result
 is good, she or someone else can tell the version control system to move
 ("merge") the drawbridge from the branch version of the castle over to
 the main version, sometimes called the master branch.
@@ -1485,8 +1485,8 @@ People need the freedom to try new things without feeling like they're
 interfering with others' work. Equally importantly, there are times when
 code needs to be isolated from the usual development churn, in order to
 get a bug fixed or a release stabilized (see
-link:#stabilizing-a-release[???] and link:#release-lines[???]in
-link:#development-cycle[???]) without worrying about tracking a moving
+<<stabilizing-a-release>> and <<release-lines>> in
+<<development-cycle>>) without worrying about tracking a moving
 target. At the same time, people need to be able to review and comment
 on experimental work, whether it's happening in the master branch or
 somewhere else. Treating branches as first-class, publishable objects
@@ -1561,12 +1561,12 @@ usually a standard syntax for expressing the changeset name. Whatever
 the appropriate syntax is for your system, encourage people to use it
 when referring to changes. Consistent expression of change names makes
 project bookkeeping much easier (as we will see in
-link:#communications[???] and link:#development-cycle[???]), and since a
+<<communications>> and <<development-cycle>>), and since a
 lot of the bookkeeping may be done by volunteers, it needs to be as easy
 as possible.
 
-See also link:#releases-and-daily-development[???]in
-link:#development-cycle[???].
+See also <<releases-and-daily-development>> in
+<<development-cycle>>.
 
 [[vc-authz]]
 ===== Authorization
@@ -1577,8 +1577,8 @@ master repository. Following the principle that when handed a hammer,
 people start looking around for nails, many projects use this feature
 with abandon, carefully granting people access to just those areas where
 they have been approved to commit, and making sure they can't commit
-anywhere else. (See link:#committers[???]in
-link:#managing-volunteers[???] for how projects decide who can put
+anywhere else. (See <<committers>> in
+<<managing-volunteers>> for how projects decide who can put
 changes where.)
 
 Exercising such tight control is usually unnecessary, and may even be
@@ -1651,7 +1651,7 @@ people to commit in areas where they're not qualified. Furthermore, in
 many projects, full (unrestricted) commit access has a special corollary
 status: it implies voting rights on project-wide questions. This
 political aspect of commit access is discussed more in
-link:#electorate[???]in link:#social-infrastructure[???].
+<<electorate>> in <<social-infrastructure>>.
 
 [[receiving-changes]]
 ==== Receiving and reviewing contributions
@@ -1687,7 +1687,7 @@ Developers and other interested parties should be encouraged to
 subscribe to the commits list, as it is the most effective way to keep
 up with what's happening in the project at the code level. Aside from
 the obvious technical benefits of peer review (see
-link:#code-review[???]), commit emails help create a sense of community,
+<<code-review>>), commit emails help create a sense of community,
 because they establish a shared environment in which people can react to
 events (commits) that they know are visible to others as well.
 
@@ -1743,7 +1743,7 @@ commit emails; sending them other material via that list would violate
 an implicit contract.
 +
 Note that this advice to set Reply-to does not contradict the
-recommendations in link:#reply-to[The Great Reply-to Debate]earlier in
+recommendations in <<reply-to>> earlier in
 this chapter. It's always okay for the _sender_ of a message to set
 Reply-to. In this case, the sender is the version control system itself,
 and it sets Reply-to in order to indicate that the appropriate place for
@@ -1781,7 +1781,7 @@ The classic ticket life cycle looks like this:
 
 1.  Someone files the ticket. They provide a summary, an initial
 description (including a reproduction recipe, if applicable; see
-link:#users-to-volunteers[???]in link:#managing-volunteers[???] for how
+<<users-to-volunteers>> in <<managing-volunteers>> for how
 to encourage good bug reports), and whatever other information the
 tracker asks for. The person who files the ticket may be totally unknown
 to the project—bug reports and feature requests are as likely to come
@@ -1811,7 +1811,7 @@ where she left off.
 +
 In this stage, or sometimes in the previous one, a developer may "take
 ownership" of the ticket and assign it to herself
-(link:#delegation-assignment[???]in link:#managing-volunteers[???]
+(<<delegation-assignment>> in <<managing-volunteers>>
 examines the assignment process in more detail). The ticket's priority
 may also be set at this stage. For example, if it is so important that
 it should delay the next release, that fact needs to be identified
@@ -1836,13 +1836,13 @@ responses. Try to guard against the latter tendency. It does no one any
 good, as the individual user in each case is not responsible for all the
 previous invalid tickets; the statistical trend is visible only from the
 developers' point of view, not the user's. (In
-link:#bug-filtering[Pre-Filtering the Bug Tracker]later in this chapter,
+<<bug-filtering>> later in this chapter,
 we'll look at techniques for reducing the number of invalid tickets.)
 Also, if different users are experiencing the same misunderstanding over
 and over, it might mean that aspect of the software needs to be
 redesigned. This sort of pattern is easiest to notice when there is an
 issue manager monitoring the bug database; see
-link:#issue-manager[???]in link:#managing-volunteers[???].
+<<issue-manager>> in <<managing-volunteers>>.
 
 Another common life event for the ticket to be closed as a duplicate
 soon after Step 1. A duplicate is when someone reports something that's
@@ -1888,13 +1888,13 @@ trackers' technical features:
 * The tracker should be connected to email, such that every change to a
 ticket, including its initial filing, causes a notification mail to go
 out to some set of appropriate recipients. See
-link:#bug-tracker-email-interaction[Interaction with Email] later in
+<<bug-tracker-email-interaction>> later in
 this chapter for more on this.
 * The form for filing tickets should have a place to record the
 reporter's email address or other contact information, so she can be
 contacted for more details. But if possible, it should not _require_ the
 reporter's email address or real identity, as some people prefer to
-report anonymously. See link:#anonymity[Anonymity and involvement]later
+report anonymously. See <<anonymity>> later
 in this chapter for more on the importance of anonymity.
 * The tracker should have APIs. I cannot stress the importance of this
 enough. If there is no way to interact with the tracker
@@ -1931,7 +1931,7 @@ minimum, the ability to create new tickets by email, the ability to
 and the ability to add new comments to a ticket by email. Some trackers
 even allow one to manipulate ticket state (e.g., change the status
 field, the assignee, etc) by email, and for people who use the tracker a
-lot, such as an link:#issue-manager[???], that can make a huge
+lot, such as an <<issue-manager>>, that can make a huge
 difference in their ability to stay on top of tracker activity and keep
 things organized.
 
@@ -1942,7 +1942,7 @@ since it makes it easy to integrate bug traffic into one's daily email
 flow. But don't let this integration give anyone the illusion that the
 total collection of bug tickets and their email traffic is the
 equivalent of the development mailing list. It's not, and
-link:#choose-the-forum[???]in link:#communications[???] discusses why
+<<choose-the-forum>> in <<communications>> discusses why
 this is important and how to manage the difference.
 
 [[bug-filtering]]
@@ -2033,7 +2033,7 @@ worse than the disease. It's better to accept that cleaning out invalid
 tickets will always be part of the project's routine maintenance, and to
 try to get as many people as possible to help.
 
-See also link:#issue-manager[???]in link:#managing-volunteers[???].
+See also <<issue-manager>> in <<managing-volunteers>>.
 
 [[irc]]
 === IRC / Real-Time Chat Systems
@@ -2082,7 +2082,7 @@ menu in the upper left corner, choose "Add webchat to your site" and
 follow the instructions.]. If your project's channel gets too noisy, you
 can divide into multiple channels, for example one for installation
 problems, another for usage questions, another for development chat, etc
-(link:#growth[???]in link:#communications[???] discusses when and how to
+(<<growth>> in <<communications>> discusses when and how to
 divide into multiple channels). But when your project is young, there
 should only be one channel, with everyone talking together. Later, as
 the user-to-developer ratio increases, separate channels may become
@@ -2245,7 +2245,7 @@ automatically updates whenever there's news from the site.
 
 This means that your open source project should probably offer an RSS
 feed (note that many of the canned hosting sites — see
-link:#canned-hosting[Canned Hosting] — offer it right out of the box).
+<<canned-hosting>> — offer it right out of the box).
 Be careful not to post so many news items each day that subscribers
 can't separate the wheat from the chaff. If there are too many news
 events, people will just ignore the feed, or even unsubscribe in

--- a/book/ch04.adoc
+++ b/book/ch04.adoc
@@ -50,8 +50,8 @@ source code and use it to start a competing project, known as a fork.
 The paradoxical thing is that the _possibility_ of forks is usually a
 much greater force in free software projects than actual forks, which
 are very rare. Because a fork is usually bad for everyone (for reasons
-examined in detail in link:#forks[???]in
-link:#managing-volunteers[???]), the more serious the threat of a fork
+examined in detail in <<forks>> in
+<<managing-volunteers>>), the more serious the threat of a fork
 becomes, the more willing people are to compromise to avoid it.
 
 Forks, or rather the potential for forks, are the reason there are no
@@ -314,7 +314,7 @@ Sometimes his concern is legitimate, for example that an important
 choice was left off or not described accurately. But other times a
 developer may be merely trying to stave off the inevitable, perhaps
 knowing that the vote probably won't go his way. See
-link:#difficult-people[???]in link:#communications[???] for how to deal
+<<difficult-people>> in <<communications>> for how to deal
 with this sort of obstructionism.
 
 Remember to specify the voting system, as there are many different
@@ -383,7 +383,7 @@ the result.
 
 (Note that this advice to be reluctant to call votes does not apply to
 the change-inclusion voting described in
-link:#stabilizing-a-release[???]in link:#development-cycle[???], where
+<<stabilizing-a-release>> in <<development-cycle>>, where
 voting is more of a communications mechanism, a means of registering
 one's involvement in the change review process so that everyone can tell
 how much review a given change has received. It also does not apply to
@@ -448,7 +448,7 @@ in favor. The exact parameters are not important; the main idea is to
 get the group to be careful about adding new committers. Similar, or
 even stricter, special requirements can apply to votes to _remove_ a
 committer, though hopefully that will never be necessary. See
-link:#committers[???]in link:#managing-volunteers[???] for more on the
+<<committers>> in <<managing-volunteers>> for more on the
 non-voting aspects of adding and removing committers.
 
 [[polls]]
@@ -528,8 +528,8 @@ archives often move and links may change. Technically, same can go for
 bug tickets, but bug trackers move somewhat less often than mail
 archives._
 
-This is the document alluded to in link:#developer-guidelines[???]in
-link:#getting-started[???]. Naturally, when the project is very young,
+This is the document alluded to in <<developer-guidelines>> in
+<<getting-started>>. Naturally, when the project is very young,
 you will have to lay down guidelines without the benefit of a long
 project history to draw on. But as the development community matures,
 you can adjust the language to reflect the way things actually turn out.

--- a/book/ch05.adoc
+++ b/book/ch05.adoc
@@ -183,7 +183,7 @@ Dual-licensing::
   traditional proprietary license for customers who want to resell it as
   part of a proprietary application of their own, and simultaneously
   under a free license for those willing to use it under open source
-  terms (see link:#dual-licensing[???]in link:#legal[???]). If the open
+  terms (see <<dual-licensing>> in <<legal>>). If the open
   source developer community is active, the software gets the benefits
   of wide-area debugging and development, yet the company still gets a
   royalty stream to support some full-time programmers.
@@ -266,7 +266,7 @@ community and the human relationships they have made there.
 The credibility a developer has accumulated cannot be transferred. To
 pick the most obvious example, an incoming developer can't inherit
 commit access from an outgoing one (see
-link:#money-vs-love[Money Can't Buy You Love] later in this chapter), so
+<<money-vs-love>> later in this chapter), so
 if the new developer doesn't already have commit access, he will have to
 submit patches until he does. But commit access is only the most easily
 quantifiable manifestation of lost influence. A long-time developer also
@@ -352,8 +352,8 @@ taken seriously. The public manifestations of a private agreement are no
 less sincere for having been coordinated beforehand, and are not harmful
 as long as they are not used to prejudicially snuff out opposing
 arguments. Their purpose is merely to inhibit the sort of people who
-like to object just to stay in shape; see link:#bikeshed[???]in
-link:#communications[???] for more about them.
+like to object just to stay in shape; see <<bikeshed>> in
+<<communications>> for more about them.
 
 [[open-motives]]
 === Be Open About Your Motivations
@@ -485,7 +485,7 @@ policy about how a new developer gets commit access. First, he submits
 some patches to the development mailing list. After enough patches have
 gone by for the other committers to see that the new contributor knows
 what he's doing, someone proposes that he just commit directly (that
-proposal is private, as described in link:#committers[???]). Assuming
+proposal is private, as described in <<committers>>). Assuming
 the committers agree, one of them mails the new developer and offers him
 direct commit access to the project's repository.
 
@@ -532,7 +532,7 @@ standards as the non-Sun developers.)
 
 The need for the funders to play by the same rules as everyone else
 means that the Benevolent Dictatorship governance model (see
-link:#benevolent-dictator[???]in link:#social-infrastructure[???]) is
+<<benevolent-dictator>> in <<social-infrastructure>>) is
 slightly harder to pull off in the presence of funding, particularly if
 the dictator works for the primary funder. Since a dictatorship has few
 rules, it is hard for the funder to prove that it's abiding by community
@@ -865,7 +865,7 @@ issues of corporate law, asset transfer, reviewing agreements, and other
 due diligence matters.
 
 Some more concrete ideas of what sorts of legal help might be useful are
-discussed in link:#legal[???]. The main thing is to make sure that
+discussed in <<legal>>. The main thing is to make sure that
 communications between the legal department and the development
 community, if they happen at all, happen with a mutual appreciation of
 the very different universes the parties are coming from. On occasion,
@@ -950,7 +950,7 @@ if possible.
 ==== Providing Hosting/Bandwidth
 
 The inexorable rise of zero-cost canned hosting sites (see
-link:#canned-hosting[???]in link:#technical-infrastructure[???]) for
+<<canned-hosting>> in <<technical-infrastructure>>) for
 open source projects has meant that it is increasingly unnecessary for
 projects to get corporate support for basic project-hosting
 infrastructure. It still happens sometimes, usually in cases where the
@@ -1020,7 +1020,7 @@ the arms-race dynamics of marketing in general. Any corporation involved
 in free software will eventually find itself considering how to market
 themselves, the software, or their relationship to the software. The
 advice below is about how to avoid common pitfalls in such an effort;
-see also link:#publicity[???]in link:#communications[???].
+see also <<publicity>> in <<communications>>.
 
 [[goldfish-bowl]]
 ==== Remember That You Are Being Watched
@@ -1108,8 +1108,8 @@ places. That's not a lot of effort, and I'm sure I'm not the only one
 who took the trouble.
 
 Transparency and verifiability are also an important part of accurate
-crediting, of course. See link:#credit[???]in
-link:#managing-volunteers[???] for more on this.
+crediting, of course. See <<credit>> in
+<<managing-volunteers>> for more on this.
 
 [[competing-products]]
 ==== Don't Bash Competing Open Source Products

--- a/book/ch06.adoc
+++ b/book/ch06.adoc
@@ -388,8 +388,8 @@ your time is valuable by being terse than by being lazy.
 
 There are many other forms of rudeness, of course, but most of them are
 not specific to free software development, and common sense is a good
-enough guide to avoid them. See also link:#prevent-rudeness[???]in
-link:#getting-started[???], if you haven't already.
+enough guide to avoid them. See also <<prevent-rudeness>> in
+<<getting-started>>, if you haven't already.
 
 [[face]]
 ==== Face
@@ -563,7 +563,7 @@ of the mail. But even then, think twice before saying something; it's
 always better to leave people wishing you'd post more than wishing you'd
 post less. (The second half of Poul-Henning Kamp's "bikeshed" post,
 referenced from
-link:#bikeshed[The Softer the Topic, the Longer the Debate], offers some
+<<bikeshed>>, offers some
 further thoughts about how to behave on a busy mailing list.)
 
 [[productive-threads]]
@@ -788,9 +788,9 @@ The first answer is, try to set things up so they don't happen. This is
 not as hopeless as it sounds:
 
 You can anticipate certain standard holy wars: they tend to come up over
-programming languages, licenses (see link:#license-compatibility[???]in
-link:#legal[???]), reply-to munging (see link:#reply-to[???]in
-link:#technical-infrastructure[???]), and a few other topics. Each
+programming languages, licenses (see <<license-compatibility>> in
+<<legal>>), reply-to munging (see <<reply-to>> in
+<<technical-infrastructure>>), and a few other topics. Each
 project usually has a holy war or two all its own, as well, which
 longtime developers will quickly become familiar with. The techniques
 for stopping holy wars, or at least limiting their damage, are pretty
@@ -1061,8 +1061,8 @@ have exercised appropriate judgement in the first place. But he agreed
 to stop posting, and the mailing lists became useable again. Part of the
 reason this strategy worked was, perhaps, the implicit threat that we
 could start restricting his posts via the moderation software normally
-used for preventing spam (see link:#spam-prevention[???]in
-link:#technical-infrastructure[???]). But the reason we were able to
+used for preventing spam (see <<spam-prevention>> in
+<<technical-infrastructure>>). But the reason we were able to
 have that option in reserve was that Fitz had gathered the necessary
 support from key people first.
 
@@ -1157,8 +1157,8 @@ guidelines before posting.
 
 Strategy (2) is an ongoing process, lasting the lifetime of the project
 and involving many participants. Of course it is partly a matter of
-having up-to-date documentation (see link:#documentation[???]in
-link:#getting-started[???]) and making sure to point people there. But
+having up-to-date documentation (see <<documentation>> in
+<<getting-started>>) and making sure to point people there. But
 it is also much more than that; the sections that follow discuss this
 strategy in detail.
 
@@ -1273,7 +1273,7 @@ individual entry in the FAQ should be directly addresseable via a direct
 URL (e.g., using HTML IDs and named anchors, tags that allow people to
 reach a particular location on the page). Point 5 means the source files
 for the FAQ should be available in a convenient way (see
-link:#version-everything[???]in link:#technical-infrastructure[???]), in
+<<version-everything>> in <<technical-infrastructure>>), in
 a format that's easy to edit.
 
 Formatting the FAQ like this is just one example of how to make a
@@ -1285,7 +1285,7 @@ happens that most mailing list archiving software long ago recognized
 the importance of these properties, which is why mailing lists tend to
 have this functionality natively, while other formats may require a
 little extra effort on the maintainer's part.
-link:#managing-volunteers[???] discusses how to spread that maintenance
+<<managing-volunteers>> discusses how to spread that maintenance
 burden across many volunteers.
 
 [[codifying-tradition]]
@@ -1304,9 +1304,9 @@ past.
 The traditions a project accumulates are as much about how to
 communicate and preserve information as they are about coding standards
 and other technical minutae. We've already looked at both sorts of
-standards, in link:#developer-documentation[???]in
-link:#getting-started[???] and link:#written-rules[???]in
-link:#social-infrastructure[???] respectively, and examples are given
+standards, in <<developer-documentation>> in
+<<getting-started>> and <<written-rules>> in
+<<social-infrastructure>> respectively, and examples are given
 there. What this section is about is how to keep such guidelines
 up-to-date as the project evolves, especially guidelines about how
 communications are managed, because those are the ones that change the
@@ -1338,8 +1338,8 @@ technical answers about the software __right now__, rather than at, say,
 people who might get involved with the project in a long term way and
 for whom community interaction guidelines might be more appropriate.
 Here's how a really busy channel handles it (compare this with the
-earlier example in link:#irc[???]in
-link:#technical-infrastructure[???]):
+earlier example in <<irc>> in
+<<technical-infrastructure>>):
 
 ....
 You are now talking on #linuxhelp
@@ -1365,8 +1365,8 @@ known that they eventually have more readers off the list than on it.
 
 Formatting can make a big difference. For example, in the Subversion
 project, we were having limited success using the bug-filtering
-technique described in link:#bug-filtering[???]in
-link:#technical-infrastructure[???]. Many bogus bug reports were still
+technique described in <<bug-filtering>> in
+<<technical-infrastructure>>. Many bogus bug reports were still
 being filed by inexperienced people, and each time it happened, the
 filer had to be educated in exactly the same way as the 500 people
 before him. One day, after one of our developers had finally gotten to
@@ -1399,7 +1399,7 @@ Static web pages are not the only venue for advertising the project's
 customs. A certain amount of interactive policing (in the
 friendly-reminder sense, not the handcuffs-and-jail sense) is also
 required. All peer review, even the commit reviews described in
-link:#code-review[???]in link:#getting-started[???], should include
+<<code-review>> in <<getting-started>>, should include
 review of people's conformance or non-conformance with project norms,
 especially with regard to communications conventions.
 
@@ -1512,7 +1512,7 @@ culture where it's normal for everyone to do it, so everyone thinks
 about forum appropriateness as a matter of course, and feels comfortable
 raising questions of forum whenever necessary in any discussion.
 Obviously, documenting the practice will help (see
-link:#written-rules[???]in link:#social-infrastructure[???]), but you'll
+<<written-rules>> in <<social-infrastructure>>), but you'll
 probably also need to remind people of it often, especially when your
 project is starting out. A good rule of thumb is: if the conversation
 looks convergent, then it's okay to keep it in the bug ticket or other
@@ -1582,13 +1582,13 @@ sure it is structured accordingly: either as one web page per release,
 as a discrete blog entry, or as some other kind of entity that can be
 linked to while still being kept distinct from other press releases in
 the same area.
-3.  If your project has an RSS feed (see link:#rss[???]), make sure the
+3.  If your project has an RSS feed (see <<rss>>), make sure the
 announcement goes out there too. This may happen automatically when you
 create the press release, depending on how things are set up at your
 site.
 4.  If the announcement is about a new release of the software, then
 update your project's entry on http://freecode.com/[freecode.com] (see
-link:#announcing[???] about creating the entry in the first place).
+<<announcing>> about creating the entry in the first place).
 Every time you update a Freecode entry, that entry goes onto the
 Freecode change list for the day. The change list is updated not only on
 Freecode itself, but on various portal sites (including
@@ -1619,7 +1619,7 @@ very low-traffic, reserved for major project announcements. Most of
 those announcements will be about new releases of the software, but
 occasionally other events, such as a fundraising drive, the discovery of
 a security vulnerability (see
-link:#security[Announcing Security Vulnerabilities])later in this
+<<security>>)later in this
 chapter, or a major shift in project direction may be posted there as
 well. Because it is low traffic and used only for important things, the
 `announce` list typically has the highest subscribership of any mailing
@@ -2004,8 +2004,8 @@ by exactly the security patch. That way, conservative admins can upgrade
 without worrying about what else they might be affecting; they also
 don't have to worry about future upgrades, because the security fix will
 be in all future releases as a matter of course. (Details of release
-procedures are discussed in link:#security-releases[???]in
-link:#development-cycle[???].)
+procedures are discussed in <<security-releases>> in
+<<development-cycle>>.)
 
 Whether or not the public fix involves a new release, do the
 announcement with roughly the same priority as you would a new release:

--- a/book/ch07.adoc
+++ b/book/ch07.adoc
@@ -72,7 +72,7 @@ release means that:
 can count on being true of every release.
 * New bugs have been added. This too can usually be counted on, except
 sometimes in the case of security releases or other one-offs (see
-link:#security-releases[Security Releases]later in this chapter).
+<<security-releases>> later in this chapter).
 * New features may have been added.
 * New configuration options may have been added, or the meanings of old
 options may have changed subtly. The installation procedures may have
@@ -98,7 +98,7 @@ nature of the changes in the release.
 
 All that in a number? Well, more or less, yes. Release numbering
 strategies are one of the oldest bikeshed discussions around (see
-link:#bikeshed[???]in link:#communications[???]), and the world is
+<<bikeshed>> in <<communications>>), and the world is
 unlikely to settle on a single, complete standard anytime soon. However,
 a few good strategies have emerged, along with one universally agreed-on
 principle: __be consistent__. Pick a numbering scheme, document it, and
@@ -136,7 +136,7 @@ go beyond three or four. The reasons why will become clear later.
 
 In addition to the numeric components, projects sometimes tack on a
 descriptive label such as "Alpha" or "Beta" (see
-link:#alpha-and-beta[???]), for example:
+<<alpha-and-beta>>), for example:
 
 ....
 Scanley 2.3.0 (Alpha)
@@ -347,7 +347,7 @@ projects that have very long release cycles, and which by their nature
 have a high proportion of conservative users who value stability above
 new features. It is not the only way to get new functionality tested in
 the wild, however. In
-link:#stabilizing-a-release[Stabilizing a Release]later in this chapter
+<<stabilizing-a-release>> later in this chapter
 we will examine another, perhaps more common, method of releasing
 potentially unstable code to the public, in which the release number is
 further marked so that people have an idea of the risk/benefit
@@ -393,7 +393,7 @@ tree remain unnaturally quiescent.
 
 The solution to these problems is to always use a release branch. A
 release branch is just a branch in the version control system (see
-link:#vc-vocabulary-branch[???]), on which the code destined for this
+<<vc-vocabulary-branch>>), on which the code destined for this
 release can be isolated from mainline development. The concept of
 release branches is certainly not original to free software; many
 proprietary development organizations use them too. However, in
@@ -436,12 +436,12 @@ use the same minor line—i.e., the same branch—for all the micro releases
 in that line.
 
 The social and technical process of stabilizing the branch for release
-is covered in link:#stabilizing-a-release[Stabilizing a Release]later in
+is covered in <<stabilizing-a-release>> later in
 this chapter. Here we are concerned just with the high-level version
 control actions that relate tothe release process. When the release
 branch is stabilized and ready, it is time to tag a snapshot from the
-branch (see link:#vc-vocabulary-tag[???]in
-link:#technical-infrastructure[???]) with a name like, e.g., "1.0.0".
+branch (see <<vc-vocabulary-tag>> in
+<<technical-infrastructure>>) with a name like, e.g., "1.0.0".
 The resultant tag represents the exact state of the project's source
 tree in the 1.0.0 release (this is useful when developers need to
 compare against an old version while tracking down a bug). The next
@@ -542,7 +542,7 @@ dig in her heels.
 
 Note that the release owner need not be the same person as the project
 leader (in cases where there is a project leader at all; see
-link:#benevolent-dictator[???]in link:#social-infrastructure[???]). In
+<<benevolent-dictator>> in <<social-infrastructure>>). In
 fact, sometimes it's good to make sure they're _not_ the same person.
 The skills that make a good development leader are not necessarily the
 same as those that make a good release owner. In something as important
@@ -554,7 +554,7 @@ may be enough reason, in most situations, to let the release owner win
 when there is a disagreement.
 
 Contrast the release owner role with the less dictatorial role described
-in link:#release-manager[Release manager]later in this chapter.
+in <<release-manager>> later in this chapter.
 
 [[release-voting]]
 ==== Voting on Changes
@@ -565,8 +565,8 @@ since the most important function of release stabilization is to
 _exclude_ changes, it's important to design the voting system in such a
 way that getting a change into the release involves positive action by
 multiple developers. Including a change should need more than just a
-simple majority (see link:#electorate[???]in
-link:#social-infrastructure[???]). Otherwise, one vote for and none
+simple majority (see <<electorate>> in
+<<social-infrastructure>>). Otherwise, one vote for and none
 against a given change would suffice to get it into the release, and an
 unfortunate dynamic would be set up whereby each developer would vote
 for her own changes, yet would be reluctant to vote against others'
@@ -585,7 +585,7 @@ struck a good balance, so I'll recommend it here. In order for a change
 to be applied to the release branch, at least three developers must vote
 in favor of it, and none against. A single "no" vote is enough to stop
 the change from being included; that is, a "no" vote in a release
-context is equivalent to a veto (see link:#veto[???]). Naturally, any
+context is equivalent to a veto (see <<veto>>). Naturally, any
 such vote must be accompanied by a justification, and in theory the veto
 could be overridden if enough people feel it is unreasonable and force a
 special vote over it. In practice, this never happens. People are
@@ -657,7 +657,7 @@ for uniquely identifying a change.]
 
 Those proposing or voting for a change are responsible for making sure
 it applies cleanly to the release branch, that is, applies without
-conflicts (see link:#vc-vocabulary-conflict[???]). If there are
+conflicts (see <<vc-vocabulary-conflict>>). If there are
 conflicts, then the entry should either point to an adjusted patch that
 does apply cleanly, or better yet to a temporary branch that holds an
 adjusted version of the change, for example:
@@ -683,8 +683,8 @@ it easier to merge the change into the release, should it get approval).
 The original revisions are provided because they're still the easiest
 entity to review, since they have the original log messages. The
 temporary branch wouldn't have those log messages; in order to avoid
-duplication of information (see link:#vc-singularity[???]in
-link:#technical-infrastructure[???]), the branch's log message for
+duplication of information (see <<vc-singularity>> in
+<<technical-infrastructure>>), the branch's log message for
 r13517 should simply say "Adjust r13222, r13223, and r13232 for backport
 to 1.1.x branch." All other information about the changes can be chased
 down at their original revisions.
@@ -692,7 +692,7 @@ down at their original revisions.
 [[release-manager]]
 ===== Release manager
 
-The actual process of merging (see link:#vc-vocabulary-merge[???])
+The actual process of merging (see <<vc-vocabulary-merge>>)
 approved changes into the release branch can be performed by any
 developer. There does not need to be one person whose job it is to merge
 changes; if there are a lot of changes, it can be better to spread the
@@ -702,7 +702,7 @@ However, although both voting and merging happen in a decentralized
 fashion, in practice there are usually one or two people driving the
 release process. This role is sometimes formally blessed as release
 manager, but it is quite different from a release owner (see
-link:#release-owner[Dictatorship by Release Owner]earlier in this
+<<release-owner>> earlier in this
 chapter) who has final say over the changes. Release managers keep track
 of how many changes are currently under consideration, how many have
 been approved, how many seem likely to be approved, etc. If they sense
@@ -714,7 +714,7 @@ release branch; it's fine if others leave that task to them, as long as
 everyone understands that the release managers are not obligated to do
 all the work unless they have explicitly committed to it. When the time
 comes to put the release out the door (see
-link:#testing-and-releasing[Testing and Releasing]later in this
+<<testing-and-releasing>> later in this
 chapter), the release managers also take care of the logistics of
 creating the final release packages, collecting digital signatures,
 uploading the packages, and making the public announcement.
@@ -728,7 +728,7 @@ form (i.e., can be interpreted, like Perl, Python, PHP, etc.) or needs
 to be compiled first (like C, C++, Java, etc.). With compiled software,
 most users will probably not compile the sources themselves, but will
 instead install from pre-built binary packages (see
-link:#binary-packages[Binary Packages]later in this chapter). However,
+<<binary-packages>> later in this chapter). However,
 those binary packages are still derived from a master source
 distribution. The point of the source package is to unambiguously define
 the release. When the project distributes "Scanley 2.5.0", what it
@@ -781,7 +781,7 @@ project's web site, other files of interest, etc. Among those other
 files should be an `INSTALL` file, sibling to the `README` file, giving
 instructions on how to build and install the software for all the
 operating systems it supports. As mentioned in
-link:#license-quickstart-applying[???]in link:#getting-started[???],
+<<license-quickstart-applying>> in <<getting-started>>,
 there should also be a `COPYING` or `LICENSE` file, giving the
 software's terms of distribution.footnote:[Your all-caps files — README,
 INSTALL, etc — may of course have ".txt" extensions, or ".md" to
@@ -821,7 +821,7 @@ little bugfix and feature enhancement. Its purpose is to give users an
 overview of what they would gain by upgrading to the new release, and to
 tell them about any incompatible changes. In fact, the changelist is
 customarily included in the announcement email (see
-link:#testing-and-releasing[Testing and Releasing]later in this
+<<testing-and-releasing>> later in this
 chapter), so write it with that audience in mind.
 
 The actual layout of the source code inside the tree should be the same
@@ -830,13 +830,13 @@ by checking out the project directly from its version control
 repository. Sometimes there are a few differences, for example because
 the package contains some generated files needed for configuration and
 compilation (see
-link:#packaging-build-install[Compilation and Installation]later in this
+<<packaging-build-install>> later in this
 chapter), or because the distribution includes third-party software that
 is not maintained by the project, but that is required and that users
 are not likely to already have. But even if the distributed tree
 corresponds exactly to some development tree in the version control
 repository, the distribution itself should not be a working copy (see
-link:#vc-vocabulary-working-copy[???]). The release is supposed to
+<<vc-vocabulary-working-copy>>). The release is supposed to
 represent a static reference point—a particular, unchangeable
 configuration of source files. If it were a working copy, the danger
 would be that the user might update it, and afterward think that he
@@ -886,7 +886,7 @@ created when she unpacks a distribution.
 When shipping a pre-release or candidate release, the qualifier is a
 part of the release number, so include it in the name of the package's
 name. For example, the ordered sequence of alpha and beta releases given
-earlier in link:#release-number-components[Release Number Components]
+earlier in <<release-number-components>>
 would result in package names like this:
 
 ....
@@ -939,8 +939,8 @@ are practically spinal reflexes for a lot of system administrators now.
 If they see familiar invocations documented in your project's `INSTALL`
 file, that instantly raises their faith that your project is generally
 aware of conventions, and that it is likely to have gotten other things
-right as well. Also, as discussed in link:#downloads[???]in
-link:#getting-started[???], having a standard build procedure pleases
+right as well. Also, as discussed in <<downloads>> in
+<<getting-started>>, having a standard build procedure pleases
 potential developers.
 
 On Windows, the standards for building and installing are a bit less
@@ -1049,7 +1049,7 @@ tested and approved by some minimum number of developers, usually three
 or more. Approval is not simply a matter of inspecting the release for
 obvious flaws; ideally, the developers download the package, build and
 install it onto a clean system, run the regression test suite (see
-link:#automated-testing[???]in link:#managing-volunteers[???]), and do
+<<automated-testing>> in <<managing-volunteers>>), and do
 some manual testing. Assuming it passes these checks, as well as any
 other release checklist criteria the project may have, the developers
 then digitally sign each container (the .tar.gz file, .zip file, etc)
@@ -1087,7 +1087,7 @@ The purpose of all this signing and checksumming is to give users a way
 to verify that the copy they receive has not been maliciously tampered
 with. Users are about to run this code on their computers—if the code
 has been tampered with, an attacker could suddenly have a back door to
-all their data. See link:#security-releases[Security Releases]later in
+all their data. See <<security-releases>> later in
 this chapter for more about paranoia.
 
 [[candidate-releases]]
@@ -1118,8 +1118,8 @@ will end up becoming the official release.
 ==== Announcing Releases
 
 Announcing a release is like announcing any other event, and should use
-the procedures described in link:#publicity[???]in
-link:#communications[???]. There are a few specific things to do for
+the procedures described in <<publicity>> in
+<<communications>>. There are a few specific things to do for
 releases, though.
 
 Whenever you write the URL to the downloadable release tarball, make
@@ -1145,8 +1145,8 @@ all the people who took the time to file good bug reports. Don't single
 out anyone by name, though, unless there's someone who is individually
 responsible for a huge piece of work, the value of which is widely
 recognized by everyone in the project. Be wary of sliding down the
-slippery slope of credit inflation (see link:#credit[???]in
-link:#managing-volunteers[???]).
+slippery slope of credit inflation (see <<credit>> in
+<<managing-volunteers>>).
 
 [[release-lines]]
 === Maintaining Multiple Release Lines
@@ -1192,7 +1192,7 @@ official releases.
 ==== Security Releases
 
 Most of the details of handling security bugs were covered in
-link:#security[???]in link:#communications[???], but there are some
+<<security>> in <<communications>>, but there are some
 special details to discuss for doing security releases.
 
 A security release is a release made solely to close a security
@@ -1392,7 +1392,7 @@ ticket to a specific future release, invite discussion, dissent, and be
 genuinely willing to be persuaded whenever possible. Never exercise
 control merely for the sake of exercising control: the more deeply
 others feel they can participate in the release planning process (see
-link:#share-management[???]in link:#managing-volunteers[???]), the
+<<share-management>> in <<managing-volunteers>>), the
 easier it will be to persuade them to share your priorities on the
 issues that really count for you.
 

--- a/book/ch08.adoc
+++ b/book/ch08.adoc
@@ -260,7 +260,7 @@ more resistant to devaluation.
 
 An important feature of technical culture is that detailed,
 dispassionate criticism is often taken as a kind of praise (as discussed
-in link:#rudeness[???]in link:#communications[???]), because of the
+in <<rudeness>> in <<communications>>), because of the
 implication that the recipient's work is worth the time required to
 analyze it. However, both of those conditions—__detailed__ and
 __dispassionate__—must be met for this to be true. For example, if
@@ -278,7 +278,7 @@ If someone does not improve in response to criticism, the solution is
 not more or stronger criticism. The solution is for the group to remove
 that person from the position of incompetence, in a way that minimizes
 hurt feelings as much as possible; see
-link:#transitions[Transitions]later in this chapter for examples. That
+<<transitions>> later in this chapter for examples. That
 is a rare occurrence, however. Most people respond pretty well to
 criticism that is specific, detailed, and contains a clear (even if
 unspoken) expectation of improvement.
@@ -483,7 +483,7 @@ Here, I am using the term "automation" broadly, to mean not only
 repeated actions where one or two variables change each time, but any
 sort of technical infrastructure that assists humans. The minimum
 standard automation required to run a project these days was described
-in link:#technical-infrastructure[???], but each project may have its
+in <<technical-infrastructure>>, but each project may have its
 own special problems too. For example, a group working on documentation
 might want to have a web site displaying the most up-to-date versions of
 the documents at all times. Since documentation is often written in a
@@ -788,8 +788,8 @@ translation manager, documentation managers, issue managers (albeit
 unofficial), and a release manager. Some of these roles we made a
 conscious decision to initiate, others just happened by themselves. Here
 we'll examine these roles, and a couple of others, in detail (except for
-release manager, which was already covered in link:#release-manager[???]
-and link:#release-owner[???]earlier in this chapter).
+release manager, which was already covered in <<release-manager>>
+and <<release-owner>> earlier in this chapter).
 
 [[manager-is-not-owner]]
 ==== "Manager" Does Not Mean "Owner"
@@ -901,7 +901,7 @@ Because this system works only if people can depend on the patch manager
 being there without fail, the role should be held formally. In
 Subversion, we advertised for it on the development and users mailing
 lists, got several volunteers, and took the first one who replied. When
-that person had to step down (see link:#transitions[Transitions]later in
+that person had to step down (see <<transitions>> later in
 this chapter), we did the same thing again. We've never tried having
 multiple people share the role, because of the communications overhead
 that would be required between them; but perhaps at very high volumes of
@@ -1031,7 +1031,7 @@ integrated way.
 Of course, this does not preclude other people in the project from
 applying documentation patches on the fly, especially small ones, as
 time permits. And the same patch manager (see
-link:#patch-manager[Patch Manager]earlier in this chapter) can track
+<<patch-manager>> earlier in this chapter) can track
 both code and documentation patches, filing them wherever the
 development and documentation teams want them, respectively. (If the
 total quantity of patches ever exceeds one human's capacity to track,
@@ -1300,11 +1300,11 @@ releases are made.
 Because in older, centralized version control systems, there was
 normally only one repository anyway, the term "commit access"
 corresponded closely to who was actually using the "commit" command (see
-link:#vc-vocabulary-commit[???]in link:#technical-infrastructure[???])
+<<vc-vocabulary-commit>> in <<technical-infrastructure>>)
 to put changes into the group's shared repository. These days it
 corresponds to those who run the "push" or "pull" commands (see
-link:#vc-vocabulary-push[???] and link:#vc-vocabulary-pull[???]in
-link:#technical-infrastructure[???]) to put changes into that
+<<vc-vocabulary-push>> and <<vc-vocabulary-pull>> in
+<<technical-infrastructure>>) to put changes into that
 repository. It is the same idea either way: the master repository is a
 social concept, not a technical concept, and the mechanics of how
 changes get into it are not important here. Open source projects
@@ -1327,7 +1327,7 @@ working side-by-side with people who cannot sets up an obvious power
 dynamic. That dynamic must be managed so that it does not harm the
 project.
 
-In link:#electorate[???]in link:#social-infrastructure[???], we already
+In <<electorate>> in <<social-infrastructure>>, we already
 discussed the mechanics of considering new committers. Here we will look
 at the standards by which potential new committers should be judged, and
 how this process should be presented to the larger community.
@@ -1409,7 +1409,7 @@ reveal information from a discussion and ballot that others assumed were
 secret.
 
 Once someone's access is revoked, that fact is unavoidably public (see
-link:#commit-access-openness[Avoid Mystery]later in this chapter), so
+<<commit-access-openness>> later in this chapter), so
 try to be as tactful as you can in how it is presented to the outside
 world.
 
@@ -1425,8 +1425,8 @@ code to other programming languages, specification files for packaging
 will not result in a problem for the core project.
 
 Since commit access is not only about committing, but about being part
-of an electorate (see link:#electorate[???]in
-link:#social-infrastructure[???]), the question naturally arises: what
+of an electorate (see <<electorate>> in
+<<social-infrastructure>>), the question naturally arises: what
 can the partial committers vote on? There is no one right answer; it
 depends on what sorts of partial commit domains your project has. In
 Subversion things are fairly simple: a partial committer can vote on
@@ -1451,14 +1451,14 @@ within the scope of her commit access, and not on matters outside that,
 and votes on procedural questions should default to the full committers,
 unless there's some reason (as decided by the full committers) to widen
 the electorate. Remember that voting should be rare anyway (see
-link:#when-to-vote[???]in link:#social-infrastructure[???]), except for
+<<when-to-vote>> in <<social-infrastructure>>), except for
 technical votes such as the change voting described in
-link:#release-voting[???]in link:#development-cycle[???].
+<<release-voting>> in <<development-cycle>>.
 
 Regarding enforcement of partial commit access: it's often best _not_ to
 have the version control system enforce partial commit domains, even if
-it is capable of doing so. See link:#vc-authz[???]in
-link:#technical-infrastructure[???] for the reasons why.
+it is capable of doing so. See <<vc-authz>> in
+<<technical-infrastructure>> for the reasons why.
 
 [[dormant-committers]]
 ==== Dormant Committers
@@ -1481,7 +1481,7 @@ school diplomas do not expire, then commit access certainly shouldn't.
 
 Sometimes a committer may ask to be removed, or to be explicitly marked
 as dormant in the list of committers (see
-link:#commit-access-openness[Avoid Mystery]below for more about that
+<<commit-access-openness>> below for more about that
 list). In these cases, the project should accede to the person's wishes,
 of course.
 
@@ -1505,8 +1505,8 @@ or something like that, in the top level of the project's source code
 tree. It should list all the full committers first, followed by the
 various partial commit domains and the members of each domain. Each
 person should be listed by name and email address, though the address
-can be encoded to prevent spam (see link:#address-hiding[???]in
-link:#technical-infrastructure[???]) if the person prefers that.
+can be encoded to prevent spam (see <<address-hiding>> in
+<<technical-infrastructure>>) if the person prefers that.
 
 Since the distinction between full commit and partial commit access is
 obvious and well defined, it is proper for the list to make that
@@ -1538,7 +1538,7 @@ one of best motivators the project has. When small contributions are
 acknowledged, people come back to do more.
 
 One of the most important features of collaborative development software
-(see link:#technical-infrastructure[???]) is that it keeps accurate
+(see <<technical-infrastructure>>) is that it keeps accurate
 records of who did what, when. Wherever possible, use these existing
 mechanisms to make sure that credit is distributed accurately, and be
 specific about the nature of the contribution. Don't just write "Thanks
@@ -1662,7 +1662,7 @@ happening in the first place. The rest of this section is about social
 forks, not short forks. To save space, I will just use the word "fork"
 instead of "social fork".
 
-In link:#forkability[???]in link:#social-infrastructure[???], we saw how
+In <<forkability>> in <<social-infrastructure>>, we saw how
 the _potential_ to fork has important effects on how projects are
 governed. But what happens when a fork actually occurs? How should you
 handle it, and what effects can you expect it to have? Conversely, when
@@ -1700,7 +1700,7 @@ philosophy or goal. Things get messier, however, when both sides feel
 they are the legitimate guardians of the original project and therefore
 have the right to continue using the original name. If there is some
 organization with trademark rights to the name (see
-link:#trademarks[???]in link:#legal[???]), or legal control over the
+<<trademarks>> in <<legal>>), or legal control over the
 domain or web pages, that usually resolves the issue by fiat: that
 organization will decide who is the original project and who is the
 fork, because it holds all the cards in a public relations war.

--- a/book/ch09.adoc
+++ b/book/ch09.adoc
@@ -141,12 +141,11 @@ applicable to the U.S. and countries with similar systems of government
 and civil service.
 
 [[starting-open-for-govs]]
-==== Being Open Source From Day One is Especially Important for
-Government Projects
+==== Being Open Source From Day One is Especially Important for Government Projects
 
-In link:#[title_title]in link:#getting-started[???], I explained why
+In <<be-open-from-day-one>> in <<getting-started>>, I explained why
 it's best for an open source project to be run in the open from the very
-beginning. That advice, particularly link:#avoid-exposure-events[???],
+beginning. That advice, particularly <<avoid-exposure-events>>,
 is if anything even more true for government code.
 
 Government projects have greater potential to be harmed by a needless

--- a/book/ch10.adoc
+++ b/book/ch10.adoc
@@ -67,7 +67,7 @@ open source software::
   moral stance on the issue, while those who prefer "open source" either
   don't view it as a matter of freedom, or are not interested in
   advertising the fact that they do. See
-  link:#free-vs-open-source[???]in link:#introduction[???] for a more
+  <<free-vs-open-source>> in <<introduction>> for a more
   detailed history of this terminological schism.
   +
   The Free Software Foundation has an excellent—utterly unobjective, but
@@ -134,7 +134,7 @@ OSI-approved::
   The FSF categorizes licenses not only by whether they are free, but
   whether they are compatible with the GNU General Public License. GPL
   compatibility is an important topic, covered in
-  link:#license-compatibility[The GPL and License Compatibility]later in
+  <<license-compatibility>> later in
   this chapter.
 proprietary, closed-source::
   The opposite of "free" or "open source." It means software distributed
@@ -195,7 +195,7 @@ copyleft::
   The canonical example of a copyleft license is still the GNU General
   Public License, which stipulates that any derivative works must also
   be licensed under the GPL; see
-  link:#license-compatibility[The GPL and License Compatibility]later in
+  <<license-compatibility>> later in
   this chapter for more.
 non-copyleft or permissive::
   A license that grants the freedoms under discussion here but that does
@@ -249,7 +249,7 @@ compatibility with other types of free licenses::
   distributed under the GPL, and without adding any further restrictions
   beyond what the GPL requires. The GPL is compatible with some free
   licenses, but not with others. This is discussed in more detail in
-  link:#license-compatibility[The GPL and License Compatibility]later in
+  <<license-compatibility>> later in
   this chapter.
 enforcement of crediting::
   Some free licenses stipulate that any use of the covered code be
@@ -314,7 +314,7 @@ between the copyleft licenses and everything else. The canonical example
 of a copyleft license is the GNU General Public License (along with its
 network-oriented variant, the Affero GNU General Public License or AGPL,
 introduced later in this chapter in
-link:#gnu-affero-gpl[The GNU Affero GPL: A Version of the GNU GPL for Server-Side Code]),
+<<gnu-affero-gpl>>),
 and one of the most important considerations in choosing the GPL or AGPL
 is the extent to which it is compatible with other licenses. For
 brevity, I'll refer just to the GPL below, but most of this applies to
@@ -354,7 +354,7 @@ enforce freedom as well.
 
 The question of whether or not this is a good way to promote free
 software is one of the most persistent holy wars on the Internet (see
-link:#holy-wars[???]in link:#communications[???]), and we won't
+<<holy-wars>> in <<communications>>), and we won't
 investigate it here. What's important for our purposes is that GPL
 compatibility is something to consider when choosing a license. The GPL
 is by far the most popular open source license, having more than twice
@@ -425,90 +425,18 @@ then choose either the GPL-3.0 or the AGPL-3.0 — the difference between
 them will be discussed below — and if you want a non-copyleft license,
 choose Apache-2.0. I've put those licenses in boldface to reflect this.
 
-* GNU General Public License version 3
-+
-(
-+
-GPL-3.0
-+
-,
-+
-gnu.org/licenses/gpl.html
-+
-)
-* GNU Affero General Public License version 3
-+
-(
-+
-AGPL-3.0
-+
-,
-+
-gnu.org/licenses/agpl.html
-+
-)
-* Mozilla Public License 2.0 (
-+
-MPL-2.0
-+
-,
-+
-mozilla.org/MPL
-+
-)
-* GNU Library or "Lesser" General Public License version 3 (
-+
-LGPL-3.0
-+
-,
-+
-gnu.org/licenses/lgpl.html
-+
-)
-* Eclipse Public License 1.0 (
-+
-EPL-1.0
-+
-,
-+
-eclipse.org/legal/epl-v10.html
-+
-)
-+
-(Note that version 2 of the EPL was almost ready as of mid-2014, and may
-be out by the time you read this.)
-* Apache License 2.0
-+
-(
-+
-Apache-2.0
-+
-,
-+
-apache.org/licenses/LICENSE-2.0
-+
-)
-* BSD 2-Clause ("Simplified" or "FreeBSD") license (
-+
-BSD-2-Clause
-+
-,
-+
-opensource.org/licenses/BSD-2-Clause
-+
-)
-* MIT license (
-+
-MIT
-+
-,
-+
-opensource.org/licenses/MIT
-+
-)
+* *GNU General Public License version 3* (`GPL-3.0`, https://gnu.org/licenses/gpl.html)
+* *GNU Affero General Public License version 3* (`AGPL-3.0`, https://gnu.org/licenses/agpl.html)
+* Mozilla Public License 2.0 (`MPL-2.0`, http://mozilla.org/MPL)
+* GNU Library or "Lesser" General Public License version 3 (`LGPL-3.0`, https://gnu.org/licenses/lgpl.html)
+* Eclipse Public License 1.0 (`EPL-1.0`, http://eclipse.org/legal/epl-v10.html) (_Note that version 2 of the EPL was almost ready as of mid-2014, and may
+be out by the time you read this._)
+* Apache License 2.0 (Apache-2.0, http://apache.org/licenses/LICENSE-2.0)
+* BSD 2-Clause ("Simplified" or "FreeBSD") license (`BSD-2-Clause`, https://opensource.org/licenses/BSD-2-Clause)
+* *MIT license* (`MIT`, https://opensource.org/licenses/MIT)
 
 The mechanics of applying a license to your project are discussed in
-link:#license-quickstart-applying[???]in link:#getting-started[???].
+<<license-quickstart-applying>> in <<getting-started>>.
 
 [[license-choosing-gpl]]
 ==== The GNU General Public License
@@ -540,7 +468,7 @@ software under the current version of the GPL while giving downstream
 recipients the option to redistribute it under any _later_ (i.e.,
 future) version. The way to offer this option is to put language like
 this in the license headers (see
-link:#license-quickstart-applying[???]in link:#getting-started[???]) of
+<<license-quickstart-applying>> in <<getting-started>>) of
 the actual source files:
 
 ___________________________________________________________________________________________________________________________________________________________________________________________________________________________________________________
@@ -562,7 +490,7 @@ it, either just to keep the software license up-to-date with legal
 developments, or to solve some future license compatibility problem that
 couldn't have been anticipated now (for example, see the compatibility
 discussion in
-link:#gnu-affero-gpl[The GNU Affero GPL: A Version of the GNU GPL for Server-Side Code]
+<<gnu-affero-gpl>>
 below).
 
 Not everyone feels the same way, however; most notably, the Linux kernel
@@ -636,8 +564,8 @@ usually goes, of course, is that since "more free" must be better than
 "less free" (after all, who's not in favor of freedom?), it follows that
 those licenses are better than the GPL.
 
-This debate is another popular holy war (see link:#holy-wars[???]in
-link:#communications[???]). Avoid participating in it, at least in
+This debate is another popular holy war (see <<holy-wars>> in
+<<communications>>). Avoid participating in it, at least in
 project forums. Don't attempt to prove that the GPL is less free, as
 free, or more free than other licenses. Instead, emphasize the specific
 reasons your project chose the GPL. If the recognizability of license
@@ -832,7 +760,7 @@ contribute to an asymmetric result. This awkwardness is reflected and in
 some ways amplified by the fact that in a proprietary relicensing
 scheme, the copyright owner must collect some kind of formal agreement
 from each contributor (see
-link:#contributor-agreements[Contributor Agreements] earlier in this
+<<contributor-agreements>> earlier in this
 chapter), in order to have the right to redistribute that contributor's
 code under a proprietary license. Because such an agreement needs to
 give the collecting entity special, one-sided rights that a typical open


### PR DESCRIPTION
Cross references were not properly converted in #2. This manually fixes all internal links to us asciidoc cross references (`<<section-name>>`).
